### PR TITLE
Fix build error caused by missing seedrandom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^6.0.55",
     "@types/ws": "0.0.37",
     "concurrently": "^3.1.0",
+    "seedrandom": "^2.4.2",
     "ts-loader": "^1.3.3",
     "typescript": "^2.1.4",
     "webpack": "^1.14.0"


### PR DESCRIPTION
```npm run-script build```

Fixes:
```
ERROR in ./frontend/src/color.ts
Module not found: Error: Cannot resolve module 'seedrandom' in /home/jotschi/workspaces/lunar/moonar-lander/frontend/src
resolve module seedrandom in /home/jotschi/workspaces/lunar/moonar-lander/frontend/src
  looking for modules in /home/jotschi/workspaces/lunar/moonar-lander/node_modules
    resolve 'file' seedrandom in /home/jotschi/workspaces/lunar/moonar-lander/node_modules
      resolve file
        /home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom doesn't exist
        /home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom.js doesn't exist
        /home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom.ts doesn't exist
    /home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom doesn't exist (module as directory)
  looking for modules in /home/jotschi/node_modules
    resolve 'file' seedrandom in /home/jotschi/node_modules
      resolve file
        /home/jotschi/node_modules/seedrandom doesn't exist
        /home/jotschi/node_modules/seedrandom.js doesn't exist
        /home/jotschi/node_modules/seedrandom.ts doesn't exist
    /home/jotschi/node_modules/seedrandom doesn't exist (module as directory)
[/home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom]
[/home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom.js]
[/home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom.ts]
[/home/jotschi/workspaces/lunar/moonar-lander/node_modules/seedrandom]
[/home/jotschi/node_modules/seedrandom]
[/home/jotschi/node_modules/seedrandom.js]
[/home/jotschi/node_modules/seedrandom.ts]
[/home/jotschi/node_modules/seedrandom]
 @ ./frontend/src/color.ts 2:17-38
```