### PR TITLE
Fix applying rotation speed

### DIFF
--- a/frontend/src/physics.ts
+++ b/frontend/src/physics.ts
@@ -52,14 +52,11 @@ export function collide(position: Vector, velocity: Vector, landerGeometry: Geom
 export function rotate(rotation: RotationDirection, rotationSpeed: number): number {
     switch (rotation) {
         case "cw":
-            return (rotationSpeed <= MAX_ROTATION_SPEED) ?
-                rotationSpeed - ROTATION_ACCELERATION : rotationSpeed;
+            return Math.max(rotationSpeed - ROTATION_ACCELERATION, -MAX_ROTATION_SPEED);
         case "ccw":
-            return (rotationSpeed >= -MAX_ROTATION_SPEED) ?
-                rotationSpeed + ROTATION_ACCELERATION : rotationSpeed;
+            return Math.min(rotationSpeed + ROTATION_ACCELERATION, MAX_ROTATION_SPEED);
         case "off":
-            return (rotationSpeed > 0) ?
-                rotationSpeed - ROTATION_DAMPING : rotationSpeed + ROTATION_DAMPING;
+            return rotationSpeed > 0 ? Math.max(rotationSpeed - ROTATION_DAMPING, 0) : Math.min(rotationSpeed + ROTATION_DAMPING, 0);
     }
 }
 


### PR DESCRIPTION
Applying the rotation acceleration is fixed, so that the rotation speed actually stays between -MAX_ROTATION_SPEED and +MAX_ROTATION_SPEED (and is set exactly on the bounding values in case it would get out of bounds)

When rotation thrusters are off, rotation damping is applied so that the rotation speed actually will reach 0 (if abs(rotationspeed) < ROTATION_DAMPING). Otherwise, rotation would never reach 0, but toggle between two values, when rotation thrusters are off.